### PR TITLE
Pvp ou PvBot Ok

### DIFF
--- a/haskell/MenusGraficos.hs
+++ b/haskell/MenusGraficos.hs
@@ -457,7 +457,7 @@ exibeOpcaoInvalida = do
 exibePlayerGanha :: IO()
 exibePlayerGanha = do
         putStrLn ""
-        putStrLn "Você derrotou o bot"
+        putStrLn "                         Você derrotou o bot"
         putStrLn ""
         putStrLn " ______________________________________________________________________ "
         putStrLn "|  8888888b.  888                                                      |"
@@ -563,6 +563,6 @@ exibePlayer2Ganha = do
 pausa :: IO()
 pausa = do
         putStrLn ""
-        putStr "Tecle Enter para continuar"
+        putStr "Tecle Enter para continuar..."
         getLine
         putStr ""

--- a/haskell/MenusGraficos.hs
+++ b/haskell/MenusGraficos.hs
@@ -482,7 +482,7 @@ exibePlayerGanha = do
 exibeBotGanha :: IO()
 exibeBotGanha = do
         putStrLn ""
-        putStrLn "O bot te derrotou"
+        putStrLn "                          O bot te derrotou"
         putStrLn ""
         putStrLn " ______________________________________________________________________ "
         putStrLn "|  888888b.    .d88888b. 88888888888                                   |"

--- a/haskell/PvBot.hs
+++ b/haskell/PvBot.hs
@@ -5,6 +5,7 @@ import MovimentosBot
 import System.Process
 import System.IO
 import PlayerOneMovimentos
+import Control.Concurrent
 
 
 --Define a vez de jogar (1 para Player1 e 2 para o bot)
@@ -59,16 +60,21 @@ batalhaPvBot player1 bot vez = do
                 if  op >= 1 && op <= 4 then do
                         let valorAtaque = designaAtaque op player1 bot
 
+                        system "cls"
+                        putStrLn "\n\n"
+                        exibePokemons player1 
+                        putStrLn "\n\n"
+
                         if op == 1 then do
                                 atualizaVidaPlayer1 op valorAtaque
-                                system "cls"
-                                putStrLn ""
+                                {- system "cls"
+                                putStrLn "" -}
                                 putStrLn ("Você se cura em " ++ show valorAtaque)
 
                         else do
                                 atualizaVidaBot op valorAtaque
-                                system "cls"
-                                putStrLn ""
+                                {- system "cls"
+                                putStrLn "" -}
                                 putStrLn ("Você ataca em " ++ show valorAtaque)
                                 
                                 arq <- openFile "ArquivosBot/pokemonVidaBot.txt" ReadMode
@@ -79,6 +85,8 @@ batalhaPvBot player1 bot vez = do
                                         guardaDadosVidaBot 100
                                         guardaDadosVidaPlayer1 100
 
+                                        system "cls"
+                                        
                                         exibePlayerGanha
                                         pausa
                                         system "cls"
@@ -86,13 +94,18 @@ batalhaPvBot player1 bot vez = do
                                 else do
                                         putStr ""
 
-                        putStrLn ""
-                        exibePokemons player1   
+                        {- putStrLn ""
+                        exibePokemons player1  -}  
                         pausa
                         system "cls"
                         batalhaPvBot player1 bot 2  
                 else do
+                        system "cls"
+                        putStrLn ""
+                        exibePokemons player1
                         exibeOpcaoInvalida
+                        threadDelay 1000000
+                        system "cls"
                         batalhaPvBot player1 bot 1                          
         else do
                 arquivo <- openFile "ArquivosBot/pokemonVidaBot.txt" ReadMode

--- a/haskell/PvBot.hs
+++ b/haskell/PvBot.hs
@@ -14,11 +14,11 @@ type Vez = Int
 inicioPvBot :: IO()
 inicioPvBot = do
         system "cls"
-        exibeCabecalhoPvBot
         menuDeSelecaoPvBot
 
 menuDeSelecaoPvBot :: IO()
 menuDeSelecaoPvBot = do
+        exibeCabecalhoPvBot
         exibeMenuDeSelecao 0
         aux <- readLn :: IO Int
         system "cls"
@@ -41,8 +41,12 @@ menuDeSelecaoPvBot = do
         else do
                 if op == 6 then return ()
                 else do
+                        system "cls"
+                        putStrLn ""
+                        exibeCabecalhoPvBot
                         exibeOpcaoInvalida
-                        pausa
+                        threadDelay 2000000
+                        system "cls"
                         menuDeSelecaoPvBot
         where nomesPokemons = ["Zeca Skull", "Pikachu", "SeaHourse", "Kakuna", "Digglet", "Eevee"]
 
@@ -99,7 +103,7 @@ batalhaPvBot player1 bot vez = do
                         putStrLn ""
                         exibePokemons player1
                         exibeOpcaoInvalida
-                        threadDelay 1000000
+                        threadDelay 2000000
                         system "cls"
                         batalhaPvBot player1 bot 1                          
         else do
@@ -107,11 +111,18 @@ batalhaPvBot player1 bot vez = do
                 vida <- hGetLine arquivo
                 hClose arquivo
 
+                system "cls"
+                putStrLn "\n\n"
+                exibePokemons bot 
+                putStrLn "\n\n"
+
                 if read vida +15 <= 20 then do
                         let cura = designaAtaque 1 bot player1
                         atualizaVidaBot 1 cura
 
                         putStrLn ("O bot se cura em "++ show cura) 
+                        pausa
+                        system "cls"
                         batalhaPvBot player1 bot 1
 
                 else do
@@ -129,13 +140,15 @@ batalhaPvBot player1 bot vez = do
                                 guardaDadosVidaBot 100
                                 guardaDadosVidaPlayer1 100
 
-                                exibeBotGanha        
+                                threadDelay 1500000
+                                system "cls"
+
+                                exibeBotGanha 
+                                threadDelay 0800000       
                                 pausa
                                 system "cls"
                                 inicioPvBot
                         else do
-                                putStrLn ""
-                                exibePokemons bot
                                 pausa
                                 system "cls"
                                 batalhaPvBot player1 bot 1

--- a/haskell/PvBot.hs
+++ b/haskell/PvBot.hs
@@ -67,14 +67,13 @@ batalhaPvBot player1 bot vez = do
 
                         if op == 1 then do
                                 atualizaVidaPlayer1 op valorAtaque
-                                {- system "cls"
-                                putStrLn "" -}
                                 putStrLn ("Você se cura em " ++ show valorAtaque)
+                                pausa
+                                system "cls"
+                                batalhaPvBot player1 bot 2 
 
                         else do
                                 atualizaVidaBot op valorAtaque
-                                {- system "cls"
-                                putStrLn "" -}
                                 putStrLn ("Você ataca em " ++ show valorAtaque)
                                 
                                 arq <- openFile "ArquivosBot/pokemonVidaBot.txt" ReadMode
@@ -86,19 +85,15 @@ batalhaPvBot player1 bot vez = do
                                         guardaDadosVidaPlayer1 100
 
                                         system "cls"
-                                        
+
                                         exibePlayerGanha
                                         pausa
                                         system "cls"
                                         inicioPvBot
                                 else do
-                                        putStr ""
-
-                        {- putStrLn ""
-                        exibePokemons player1  -}  
-                        pausa
-                        system "cls"
-                        batalhaPvBot player1 bot 2  
+                                        pausa
+                                        system "cls"
+                                        batalhaPvBot player1 bot 2  
                 else do
                         system "cls"
                         putStrLn ""
@@ -139,12 +134,10 @@ batalhaPvBot player1 bot vez = do
                                 system "cls"
                                 inicioPvBot
                         else do
-                                putStr ""
-                
-                putStrLn ""
-                exibePokemons bot   
-                pausa
-                system "cls"
-                batalhaPvBot player1 bot 1
+                                putStrLn ""
+                                exibePokemons bot
+                                pausa
+                                system "cls"
+                                batalhaPvBot player1 bot 1
         
         

--- a/haskell/PvP.hs
+++ b/haskell/PvP.hs
@@ -101,9 +101,7 @@ batalhaPvP player1 player2 vez = do
                                         pausa
                                         system "cls"
                                         print ""
-                                        --inicioPvP
                                 else do
-                                        --putStr ""
                                         putStrLn ""
                                         exibePokemons player1
                                         pausa
@@ -149,9 +147,7 @@ batalhaPvP player1 player2 vez = do
                                         pausa
                                         system "cls"
                                         print ""
-                                        --inicioPvP
                                 else do
-                                        --putStr ""
                                         putStrLn ""
                                         exibePokemons player2
                                         pausa

--- a/haskell/PvP.hs
+++ b/haskell/PvP.hs
@@ -5,6 +5,7 @@ import System.Process
 import System.IO
 import PlayerOneMovimentos
 import PlayerTwoMovimentos
+import Control.Concurrent
 
 --Define a vez de jogar (1 para Player1 e 2 para o bot)
 type Vez = Int
@@ -31,8 +32,12 @@ menuDeSelecaoPlayer1 = do
         else do
                 if op1 == 6 then return ()
                 else do
+                        system "cls"
+                        putStrLn ""
+                        exibeCabecalhoPvP
                         exibeOpcaoInvalida
-                        pausa
+                        threadDelay 2000000
+                        system "cls"
                         menuDeSelecaoPlayer1
 
         where nomesPokemons = ["Zeca Skull", "Pikachu", "SeaHourse", "Kakuna", "Digglet", "Eevee"]
@@ -55,8 +60,12 @@ menuDeSelecaoPlayer2 op1 = do
         else do
                 if op2 == 6 then menuDeSelecaoPlayer1
                 else do
+                        system "cls"
+                        putStrLn ""
+                        exibeCabecalhoPvP
                         exibeOpcaoInvalida
-                        pausa
+                        threadDelay 2000000
+                        system "cls"
                         menuDeSelecaoPlayer2 op1
 
         where nomesPokemons = ["Zeca Skull", "Pikachu", "SeaHourse", "Kakuna", "Digglet", "Eevee"]
@@ -108,7 +117,12 @@ batalhaPvP player1 player2 vez = do
                                         system "cls"
                                         batalhaPvP player1 player2 2   
                 else do
+                        system "cls"
+                        putStrLn ""
+                        exibePokemons player1
                         exibeOpcaoInvalida
+                        threadDelay 2000000
+                        system "cls"
                         batalhaPvP player1 player2 1
                               
         else do
@@ -154,7 +168,12 @@ batalhaPvP player1 player2 vez = do
                                         system "cls"
                                         batalhaPvP player1 player2 1  
                 else do
+                        system "cls"
+                        putStrLn ""
+                        exibePokemons player1
                         exibeOpcaoInvalida
+                        threadDelay 2000000
+                        system "cls"
                         batalhaPvP player1 player2 2
 
 

--- a/haskell/PvP.hs
+++ b/haskell/PvP.hs
@@ -11,12 +11,12 @@ type Vez = Int
 
 inicioPvP :: IO()
 inicioPvP = do
-        exibeCabecalhoPvP
         menuDeSelecaoPlayer1
         
         
 menuDeSelecaoPlayer1 :: IO()
 menuDeSelecaoPlayer1 = do
+        exibeCabecalhoPvP
         exibeMenuDeSelecao 1
         aux <- readLn :: IO Int
         system "cls"
@@ -40,6 +40,7 @@ menuDeSelecaoPlayer1 = do
 menuDeSelecaoPlayer2 :: Int -> IO()
 menuDeSelecaoPlayer2 op1 = do
         system "cls"
+        exibeCabecalhoPvP
         exibeMenuDeSelecao 2
         aux <- readLn :: IO Int
         system "cls"
@@ -99,15 +100,15 @@ batalhaPvP player1 player2 vez = do
                                         exibePlayer1Ganha
                                         pausa
                                         system "cls"
-                                        inicioPvP
+                                        print ""
+                                        --inicioPvP
                                 else do
-                                        putStr ""
-
-                        putStrLn ""
-                        exibePokemons player1   
-                        pausa
-                        system "cls"
-                        batalhaPvP player1 player2 2   
+                                        --putStr ""
+                                        putStrLn ""
+                                        exibePokemons player1
+                                        pausa
+                                        system "cls"
+                                        batalhaPvP player1 player2 2   
                 else do
                         exibeOpcaoInvalida
                         batalhaPvP player1 player2 1
@@ -147,14 +148,15 @@ batalhaPvP player1 player2 vez = do
                                         exibePlayer2Ganha
                                         pausa
                                         system "cls"
-                                        inicioPvP
+                                        print ""
+                                        --inicioPvP
                                 else do
-                                        putStr ""
-                        putStrLn ""
-                        exibePokemons player2   
-                        pausa
-                        system "cls"
-                        batalhaPvP player1 player2 1  
+                                        --putStr ""
+                                        putStrLn ""
+                                        exibePokemons player2
+                                        pausa
+                                        system "cls"
+                                        batalhaPvP player1 player2 1  
                 else do
                         exibeOpcaoInvalida
                         batalhaPvP player1 player2 2


### PR DESCRIPTION
Removido bugs de PvP:
    -voltar pro menu anterior após uma luta acabar
Removido bugs de PvBot:
    -voltar pro menu anterior após uma luta acabar
    -Print de cura do bot corrigido

Adicionado delay para mensagens de entrada invalida e vitória do bot. 
Prints de valor de dano/ cura foram rearranjados nos métodos para que apareça após a imagem do Pokémon
Prints de entrada invalida são antecipadas pelo ultimo print, porém parcial